### PR TITLE
Fix naming convention issues causing build errors

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,7 +21,7 @@ import * as $ChatButtons from "./ChatButtons";
 import * as $Commands from "./Commands";
 import * as $ContextMenu from "./ContextMenu";
 import * as $DataStore from "./DataStore";
-import * as $MarkdownRules from "./MarkdownRules";
+import * as $MarkdownRules from "./MarkDownRules";
 import * as $MemberListDecorators from "./MemberListDecorators";
 import * as $MessageAccessories from "./MessageAccessories";
 import * as $MessageDecorations from "./MessageDecorations";

--- a/src/plugins/_api/markDownRules.ts
+++ b/src/plugins/_api/markDownRules.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { patchMarkdownRules } from "@api/MarkdownRules";
+import { patchMarkdownRules } from "@api/MarkDownRules";
 import { Devs } from "@utils/constants";
 import definePlugin, { StartAt } from "@utils/types";
 


### PR DESCRIPTION
A few of the file paths in imports are capitalised incorrectly, causing errors (this might have slipped through because of a linter config, not sure)
![2559c9d82645c77721075fd8cd0856c0](https://github.com/programminglaboratorys/Vencord/assets/149597648/b9c630cf-cb33-4076-a836-a7516939fafe)
